### PR TITLE
Fix node2vec form

### DIFF
--- a/src/components/GraphEmbeddings/FastRP/1.3/Form.js
+++ b/src/components/GraphEmbeddings/FastRP/1.3/Form.js
@@ -4,7 +4,7 @@ import {ProjectedGraphWithWeights} from "../../../Form/ProjectedGraph";
 import {StoreProperty} from "../../../Form/StoreProperty";
 import {OpenCloseSection} from "../../../Form/OpenCloseSection";
 
-const Node2VecForm = ({
+const FastRPForm = ({
                           readOnly, label, relationshipType, labelOptions, relationshipTypeOptions, relationshipOrientationOptions,
                           propertyKeyOptions, writeProperty, onChange, weightProperty, defaultValue, direction, persist, children,
                           embeddingSize, normalizationStrength, maxIterations
@@ -53,4 +53,4 @@ const Parameters = ({ embeddingSize, normalizationStrength, onChange, readOnly, 
     </OpenCloseSection>
 }
 
-export default Node2VecForm
+export default FastRPForm

--- a/src/components/GraphEmbeddings/FastRP/1.4/Form.js
+++ b/src/components/GraphEmbeddings/FastRP/1.4/Form.js
@@ -4,7 +4,7 @@ import {ProjectedGraphWithWeights} from "../../../Form/ProjectedGraph";
 import {StoreProperty} from "../../../Form/StoreProperty";
 import {OpenCloseSection} from "../../../Form/OpenCloseSection";
 
-const Node2VecForm = ({
+const FastRPForm = ({
                           readOnly, label, relationshipType, labelOptions, relationshipTypeOptions, relationshipOrientationOptions,
                           propertyKeyOptions, writeProperty, onChange, weightProperty, defaultValue, direction, persist, children,
                           embeddingDimension, normalizationStrength
@@ -50,4 +50,4 @@ const Parameters = ({ embeddingDimension, normalizationStrength, onChange, readO
     </OpenCloseSection>
 }
 
-export default Node2VecForm
+export default FastRPForm

--- a/src/components/GraphEmbeddings/algorithmsDictionary.js
+++ b/src/components/GraphEmbeddings/algorithmsDictionary.js
@@ -1,7 +1,8 @@
 import {runAlgorithm} from "../../services/embedding"
 import {embeddingParams} from "../../services/queries";
 import Result from "./Result";
-import Node2VecForm from "./Node2Vec/1.3/Form";
+import Node2VecForm_1Point3 from "./Node2Vec/1.3/Form";
+import Node2VecForm_1Point4 from "./Node2Vec/1.4/Form";
 import FastRPForm_1Point4 from "./FastRP/1.4/Form";
 import FastRPForm_1Point3 from "./FastRP/1.3/Form";
 
@@ -22,7 +23,7 @@ const commonRelWeightParameters = {
 const node2Vec1_4 = {
     "Node2Vec": {
         algorithmName: "gds.alpha.node2vec",
-        Form: Node2VecForm,
+        Form: Node2VecForm_1Point4,
         parametersBuilder: embeddingParams,
         service: runAlgorithm,
         ResultView: Result,
@@ -57,7 +58,7 @@ LIMIT toInteger($limit)`
 const node2Vec1_3 = {
     "Node2Vec": {
         algorithmName: "gds.alpha.node2vec",
-        Form: Node2VecForm,
+        Form: Node2VecForm_1Point3,
         parametersBuilder: embeddingParams,
         service: runAlgorithm,
         ResultView: Result,

--- a/src/components/SpecificTask.js
+++ b/src/components/SpecificTask.js
@@ -18,6 +18,6 @@ export const SpecificTask = (props) => {
         })}
         task={currentTask}
         totalPages={tasks.length}
-        gdsVersion="1.3"
+        gdsVersion={props.metadata.versions.gdsVersion}
     />
 }


### PR DESCRIPTION
I've added the missing reference to node2vec form 1.4.

I've also removed the hardcoded GDS version from results and renamed fastRPForms